### PR TITLE
chore: fix json-rpc node selection logic

### DIFF
--- a/gateway/json_rpc_server.go
+++ b/gateway/json_rpc_server.go
@@ -409,7 +409,7 @@ func checkRequestManually(w http.ResponseWriter, r *http.Request) {
 			json.Unmarshal(body, &msg)
 		}
 
-		if msg.Error == nil || msg.Result != nil {
+		if msg.Error == nil && msg.Result != nil {
 			msg.ID = ensureResponseID(msg.ID)
 			json.NewEncoder(w).Encode(msg)
 			return

--- a/gateway/json_rpc_server.go
+++ b/gateway/json_rpc_server.go
@@ -409,7 +409,7 @@ func checkRequestManually(w http.ResponseWriter, r *http.Request) {
 			json.Unmarshal(body, &msg)
 		}
 
-		if msg.Error != nil || msg.Result != nil {
+		if msg.Error == nil || msg.Result != nil {
 			msg.ID = ensureResponseID(msg.ID)
 			json.NewEncoder(w).Encode(msg)
 			return


### PR DESCRIPTION
The old logic selects a node when an error is present (`msg.Error != nil`) which is the exact opposite of what we want 😅 

New only selects a node when there are no errors **_and_** the response isn't empty